### PR TITLE
Fix GET sales API

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ Leanpub.prototype.sales = function(options, callback){
 /* GET */
 
 Leanpub.prototype.get = function(url, callback){
-  request.get(url, { form: { api_key: this.key } }, 
+  request.get(url + '?api_key=' + this.key, 
     function(err, res, body){
       callback(err, JSON.parse(body));
     }

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ Leanpub.prototype.sales = function(options, callback){
   var url;
 
   if (options.report === 'summary'){
-    url = this.url + options.slug + '/sales.json';
+    url = this.url + options.slug + '/royalties.json';
   } else if (options.report === 'all'){
     url = this.url + options.slug + '/individual_purchases.json';
   } else {


### PR DESCRIPTION
👋

Thanks for your wonderful work 11 years ago. I'm trying to re-host my old landing page and found that the Leanpub API has changed.

- sales.json is now called royalties.json
- API_KEY seems to have turned into a query param

Figured I'd make a pull request in case you see this. No worries if not :)